### PR TITLE
Fix site deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "webpack --mode=production",
     "storybook": "start-storybook -p 9001",
     "docs:dev": "docz dev",
-    "docs:build": "docz build"
+    "docs:build": "docz build && cp ./public/CNAME docs"
   },
   "publishConfig": {
     "access": "public"

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+alys.js.org


### PR DESCRIPTION
Building should include copying the CNAME file from `/public` to the build destination.